### PR TITLE
Zig update

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,6 @@
 /target
 /local
-zig-cache/
+.zig-cache/
 zig-out/
 *.log
 *.w4on2

--- a/example/build.zig
+++ b/example/build.zig
@@ -3,16 +3,16 @@ const std = @import("std");
 pub fn build(b: *std.Build) !void {
     const exe = b.addExecutable(.{
         .name = "cart",
-        .root_source_file = .{ .path = "src/main.zig" },
+        .root_source_file = b.path("src/main.zig"),
         .target = b.resolveTargetQuery(.{
             .cpu_arch = .wasm32,
             .os_tag = .freestanding,
         }),
         .optimize = .ReleaseSmall, // b.standardOptimizeOption(.{}),
     });
-    exe.addIncludePath(.{ .path = "../runtime/" });
+    exe.addIncludePath(b.path("../runtime/"));
     exe.addCSourceFile(.{
-        .file = .{ .path = "../runtime/w4on2.c" },
+        .file = b.path("../runtime/w4on2.c"),
         .flags = &.{"-D__W4ON2_WASM4_TRACEF"},
     });
 


### PR DESCRIPTION
Some very minor changes in order to build the example using a recent version of `zig` :zap: 
_(currently 0.14.0-dev.1637+8c232922b)_

> [!Tip]
> I've started documenting usage of the **w4on2** plugin under Linux in [this Gist](https://gist.github.com/peterhellberg/956322db6f5bcad324aa69ecacae793e)